### PR TITLE
Fix: update title formatting to handle undefined titles

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,7 +9,7 @@ import { ZiggyVue } from '../../vendor/tightenco/ziggy'
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel'
 
 createInertiaApp({
-  title: title => `${title} - ${appName}`,
+  title: title => (title ? `${title} - ${appName}` : appName),
   resolve: name =>
     resolvePageComponent(
       `./Pages/${name}.vue`,


### PR DESCRIPTION
Fix del título de la pestaña del navegador para mantener branding correcto en todos los entornos.

### Qué se corrige
- Ajuste del formateo del título en Inertia para evitar - Fontray cuando la página no define título:
  - Antes: \${title} - ${appName}\``
  - Ahora: si title está vacío, se muestra solo appName.

### Result
- Home: Fontray (sin guion inicial).
- Resto de páginas: <Título> - Fontray.

### Verification
- Validación local del título en Home y páginas internas.
- Build frontend ejecutado correctamente.