### PR TITLE
feat: serve the app on a custom domain via CloudFront

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -105,6 +105,8 @@ constructs:
     website:
         type: server-side-website
         versionedAssets: true # zero-downtime deploys for assets
+        domain: fontray.dpdns.org
+        certificate: arn:aws:acm:us-east-1:058264330199:certificate/969ae28b-ffc4-466f-bc23-57bb7a1c9db4
         assets:
             '/build/*': public/build
             '/images/*': public/images


### PR DESCRIPTION
## Summary
- Point the `website` construct at `fontray.dpdns.org` (free domain via
  DigitalPlat, DNS delegated to Cloudflare) instead of the default
  CloudFront domain.
- Uses the ACM certificate already issued and validated for this domain.

## Test plan
- [x] DNS delegation confirmed (NS records resolve to Cloudflare).
- [x] Certificate status: ISSUED.
- [x] Merge and confirm the deploy attaches the domain to CloudFront
      cleanly (this changes a CloudFormation resource, first run may
      take longer than usual while CloudFront updates).
- [x] Confirm https://fontray.dpdns.org serves the site after deploy.