### PR TITLE
Fix PDF page extraction and clean up leaked temp files

### DIFF
--- a/app/Services/PdfFirstPageImageExtractor.php
+++ b/app/Services/PdfFirstPageImageExtractor.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use Illuminate\Http\UploadedFile;
+use Imagick;
 use Intervention\Image\Drivers\Imagick\Driver;
 use Intervention\Image\ImageManager;
 
@@ -18,9 +19,26 @@ class PdfFirstPageImageExtractor
 
         $outputPath = $tempPath.'.png';
 
-        $manager = new ImageManager(new Driver);
-        $image = $manager->read($pdf->getRealPath().'[0]');
-        $image->toPng()->save($outputPath);
+        try {
+            // Imagick's own page-selector syntax ("path[0]") must be resolved by
+            // Imagick itself: Intervention's file-path decoder rejects it outright
+            // because is_file('path[0]') is always false, so we decode the first
+            // page via Imagick directly and hand the resulting object to Intervention.
+            $firstPage = new Imagick;
+            $firstPage->readImage($pdf->getRealPath().'[0]');
+
+            $manager = new ImageManager(new Driver);
+            $image = $manager->read($firstPage);
+            $image->toPng()->save($outputPath);
+        } finally {
+            @unlink($tempPath);
+        }
+
+        app()->terminating(function () use ($outputPath) {
+            if (is_file($outputPath)) {
+                @unlink($outputPath);
+            }
+        });
 
         return new UploadedFile(
             $outputPath,

--- a/tests/Fixtures/blank_page.pdf
+++ b/tests/Fixtures/blank_page.pdf
@@ -1,0 +1,14 @@
+%PDF-1.1
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]>>endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000052 00000 n
+0000000101 00000 n
+trailer<</Size 4/Root 1 0 R>>
+startxref
+149
+%%EOF

--- a/tests/Unit/PdfFirstPageImageExtractorTest.php
+++ b/tests/Unit/PdfFirstPageImageExtractorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\PdfFirstPageImageExtractor;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class PdfFirstPageImageExtractorTest extends TestCase
+{
+    private function makeExtractor(): PdfFirstPageImageExtractor
+    {
+        return app(PdfFirstPageImageExtractor::class);
+    }
+
+    private function fakePdf(): UploadedFile
+    {
+        return new UploadedFile(
+            base_path('tests/Fixtures/blank_page.pdf'),
+            'blank_page.pdf',
+            'application/pdf',
+            null,
+            true
+        );
+    }
+
+    private function tempFilesMatching(string $pattern): array
+    {
+        return glob(sys_get_temp_dir().DIRECTORY_SEPARATOR.$pattern) ?: [];
+    }
+
+    public function test_extract_returns_a_png_of_the_first_page(): void
+    {
+        $extractor = $this->makeExtractor();
+
+        $result = $extractor->extract($this->fakePdf());
+
+        $this->assertTrue(is_file($result->getRealPath()));
+        $this->assertSame('image/png', $result->getMimeType());
+        $this->assertSame('blank_page-page-1.png', $result->getClientOriginalName());
+
+        @unlink($result->getRealPath());
+    }
+
+    public function test_extract_does_not_leak_the_raw_tempnam_file(): void
+    {
+        $before = $this->tempFilesMatching('pdf-page-1-*');
+
+        $result = $extractor = $this->makeExtractor()->extract($this->fakePdf());
+
+        $rawTempFilesLeftBehind = array_diff(
+            $this->tempFilesMatching('pdf-page-1-*'),
+            $before,
+            [$result->getRealPath()]
+        );
+
+        $this->assertSame([], $rawTempFilesLeftBehind, 'The tempnam() placeholder file should be removed once the PNG is written.');
+
+        @unlink($result->getRealPath());
+    }
+
+    public function test_extract_schedules_the_output_png_for_cleanup_after_the_app_terminates(): void
+    {
+        $result = $this->makeExtractor()->extract($this->fakePdf());
+        $outputPath = $result->getRealPath();
+
+        $this->assertTrue(is_file($outputPath));
+
+        $this->app->terminate();
+
+        $this->assertFalse(is_file($outputPath), 'The extracted PNG should be deleted once the request has terminated.');
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `PdfFirstPageImageExtractor`: Imagick's `"path[0]"` page-selector
  syntax was rejected by Intervention's file-path decoder because
  `is_file('path[0]')` is always false — PDF extraction has never
  actually succeeded in production, silently masked by the generic
  error handler in `FontController`. Now the first page is decoded
  with Imagick directly and the resolved object is handed to
  Intervention.
- Fix a temp-file leak: the `tempnam()` placeholder file is now
  removed immediately, and the output PNG is scheduled for cleanup
  via `app()->terminating()` once the request finishes (needed
  because it's still read later for font identification and history
  storage). Prevents `/tmp` from filling up on a warm Lambda instance.

## Changes
- `app/Services/PdfFirstPageImageExtractor.php`
- `tests/Unit/PdfFirstPageImageExtractorTest.php` (new — exercises the
  real extractor instead of a mock)
- `tests/Fixtures/blank_page.pdf` (new minimal PDF fixture)

## Test plan
- [x] All 55 tests pass
- [x] New unit test verifies real extraction succeeds, the raw tempnam
  file is not leaked, and the output PNG is deleted after termination
- [x] Verified manually that the previous code always threw
  `DecoderException` on a real PDF, confirming the pre-existing bug