### PR TITLE
Extract a typed classifier for WhatFontIs API errors

### DIFF
--- a/app/Services/FontIdentificationService.php
+++ b/app/Services/FontIdentificationService.php
@@ -2,12 +2,17 @@
 
 namespace App\Services;
 
+use App\Services\WhatFontIs\FontApiErrorClassifier;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class FontIdentificationService
 {
+    public function __construct(
+        private FontApiErrorClassifier $errorClassifier
+    ) {}
+
     public function identify(UploadedFile $image): array
     {
         if (config('services.whatfontis.mock')) {
@@ -35,37 +40,13 @@ class FontIdentificationService
                     'response' => $errorMessage,
                 ]);
 
-                if ($statusCode === 429 || stripos($errorMessage, 'rate limit') !== false) {
-                    return [
-                        'success' => false,
-                        'message' => 'Has alcanzado temporalmente el límite de solicitudes. Por favor, inténtalo más tarde.',
-                        'status' => 429,
-                    ];
-                } elseif (stripos($errorMessage, 'too large') !== false) {
-                    return [
-                        'success' => false,
-                        'message' => 'La imagen es demasiado grande. Por favor, usa una imagen más pequeña o de menor resolución.',
-                        'status' => 400,
-                    ];
-                } elseif (stripos($errorMessage, 'No text box detected') !== false) {
-                    return [
-                        'success' => false,
-                        'message' => 'No se detectó texto en la imagen. Asegúrate de que la imagen contenga texto claro y legible.',
-                        'status' => 400,
-                    ];
-                } elseif (stripos($errorMessage, 'No characters detected') !== false || stripos($errorMessage, 'No Characters Found') !== false || stripos($errorMessage, 'No chars found') !== false) {
-                    return [
-                        'success' => false,
-                        'message' => 'No se detectaron caracteres legibles en la imagen. Esta herramienta funciona mejor con texto normal en lugar de logotipos muy estilizados. Intenta con una imagen que contenga texto más convencional.',
-                        'status' => 400,
-                    ];
-                } else {
-                    return [
-                        'success' => false,
-                        'message' => 'Error al procesar la imagen. Por favor, inténtalo de nuevo con una imagen diferente.',
-                        'status' => 500,
-                    ];
-                }
+                $error = $this->errorClassifier->classify($statusCode, $errorMessage);
+
+                return [
+                    'success' => false,
+                    'message' => $error->message(),
+                    'status' => $error->httpStatus(),
+                ];
             }
 
             $data = $response->json();

--- a/app/Services/WhatFontIs/FontApiError.php
+++ b/app/Services/WhatFontIs/FontApiError.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services\WhatFontIs;
+
+enum FontApiError
+{
+    case RateLimit;
+    case ImageTooLarge;
+    case NoTextDetected;
+    case NoCharactersDetected;
+    case Unknown;
+
+    public function httpStatus(): int
+    {
+        return match ($this) {
+            self::RateLimit => 429,
+            self::ImageTooLarge, self::NoTextDetected, self::NoCharactersDetected => 400,
+            self::Unknown => 500,
+        };
+    }
+
+    public function message(): string
+    {
+        return match ($this) {
+            self::RateLimit => 'Has alcanzado temporalmente el límite de solicitudes. Por favor, inténtalo más tarde.',
+            self::ImageTooLarge => 'La imagen es demasiado grande. Por favor, usa una imagen más pequeña o de menor resolución.',
+            self::NoTextDetected => 'No se detectó texto en la imagen. Asegúrate de que la imagen contenga texto claro y legible.',
+            self::NoCharactersDetected => 'No se detectaron caracteres legibles en la imagen. Esta herramienta funciona mejor con texto normal en lugar de logotipos muy estilizados. Intenta con una imagen que contenga texto más convencional.',
+            self::Unknown => 'Error al procesar la imagen. Por favor, inténtalo de nuevo con una imagen diferente.',
+        };
+    }
+}

--- a/app/Services/WhatFontIs/FontApiErrorClassifier.php
+++ b/app/Services/WhatFontIs/FontApiErrorClassifier.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Services\WhatFontIs;
+
+class FontApiErrorClassifier
+{
+    /**
+     * Substrings observed in WhatFontIs error responses, checked in order.
+     * Keyed by needle rather than status code because the provider reports
+     * most error kinds as a 400 with a distinguishing message in the body.
+     *
+     * @var array<string, FontApiError>
+     */
+    private const BODY_NEEDLES = [
+        'rate limit' => FontApiError::RateLimit,
+        'too large' => FontApiError::ImageTooLarge,
+        'no text box detected' => FontApiError::NoTextDetected,
+        'no characters detected' => FontApiError::NoCharactersDetected,
+        'no characters found' => FontApiError::NoCharactersDetected,
+        'no chars found' => FontApiError::NoCharactersDetected,
+    ];
+
+    public function classify(int $statusCode, string $body): FontApiError
+    {
+        if ($statusCode === 429) {
+            return FontApiError::RateLimit;
+        }
+
+        foreach (self::BODY_NEEDLES as $needle => $error) {
+            if (stripos($body, $needle) !== false) {
+                return $error;
+            }
+        }
+
+        return FontApiError::Unknown;
+    }
+}

--- a/tests/Unit/WhatFontIs/FontApiErrorClassifierTest.php
+++ b/tests/Unit/WhatFontIs/FontApiErrorClassifierTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\WhatFontIs;
+
+use App\Services\WhatFontIs\FontApiError;
+use App\Services\WhatFontIs\FontApiErrorClassifier;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class FontApiErrorClassifierTest extends TestCase
+{
+    private function classifier(): FontApiErrorClassifier
+    {
+        return new FontApiErrorClassifier;
+    }
+
+    public static function bodyProvider(): array
+    {
+        return [
+            'rate limit text' => ['API rate limit exceeded', 400, FontApiError::RateLimit],
+            'image too large' => ['Image too large', 400, FontApiError::ImageTooLarge],
+            'no text box detected' => ['No text box detected', 400, FontApiError::NoTextDetected],
+            'no characters detected' => ['No characters detected', 400, FontApiError::NoCharactersDetected],
+            'no Characters Found variant' => ['No Characters Found', 400, FontApiError::NoCharactersDetected],
+            'no chars found variant' => ['No chars found', 400, FontApiError::NoCharactersDetected],
+            'unrecognized body' => ['Internal Server Error', 500, FontApiError::Unknown],
+        ];
+    }
+
+    #[DataProvider('bodyProvider')]
+    public function test_classifies_known_body_needles(string $body, int $status, FontApiError $expected): void
+    {
+        $this->assertSame($expected, $this->classifier()->classify($status, $body));
+    }
+
+    public function test_a_429_status_is_always_classified_as_rate_limit_even_without_known_text(): void
+    {
+        $result = $this->classifier()->classify(429, 'Too Many Requests');
+
+        $this->assertSame(FontApiError::RateLimit, $result);
+    }
+
+    public function test_rate_limit_text_takes_priority_over_other_needles_in_the_same_body(): void
+    {
+        $result = $this->classifier()->classify(400, 'rate limit reached: image too large to retry');
+
+        $this->assertSame(FontApiError::RateLimit, $result);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the 30-line if/elseif chain in `FontIdentificationService` that matched substrings directly against the WhatFontIs response body with a `FontApiErrorClassifier` that resolves a typed `FontApiError` enum from the response status and body.
- The enum (`FontApiError`) centralizes the error → HTTP status → message mapping in one place instead of scattering it across return statements, making it easy to add a new error kind without touching the service.

## Changes
- `app/Services/WhatFontIs/FontApiError.php` (new)
- `app/Services/WhatFontIs/FontApiErrorClassifier.php` (new)
- `app/Services/FontIdentificationService.php` (now delegates to the classifier)
- `tests/Unit/WhatFontIs/FontApiErrorClassifierTest.php` (new)

## Test plan
- [x] All 64 tests pass
- [x] Behavior unchanged: a 429 status always wins, and the body-needle priority order (rate limit, too large, no text box, no characters) is preserved — verified via the existing `FontIdentificationServiceTest` suite plus new classifier-focused unit tests covering each needle, the unknown fallback, and priority when a body matches more than one needle