### PR TITLE
Store history images on an explicitly private disk

### DIFF
--- a/app/Http/Controllers/FontController.php
+++ b/app/Http/Controllers/FontController.php
@@ -48,7 +48,7 @@ class FontController extends Controller
 
             try {
                 $fileToPersist = $file;
-                $imageReference = $fileToPersist->store('images/history', 'public');
+                $imageReference = $fileToPersist->store('images/history', 'history-images');
             } catch (\Throwable) {
                 // Mantener compatibilidad en caso de fallo al persistir imagen.
             }
@@ -105,11 +105,11 @@ class FontController extends Controller
             abort(404);
         }
 
-        if (! Storage::disk('public')->exists($imageReference)) {
+        if (! Storage::disk('history-images')->exists($imageReference)) {
             abort(404);
         }
 
-        return Storage::disk('public')->response($imageReference);
+        return Storage::disk('history-images')->response($imageReference);
     }
 
     private function resolveHistoryImageUrl(SearchHistory $history): ?string

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -38,10 +38,13 @@ return [
             'report' => false,
         ],
 
-        'public' => [
-            'driver' => env('FILESYSTEM_PUBLIC_DRIVER', 'local'),
+        // Stores history images. Never expose this disk's URLs directly: it is
+        // deliberately private so that access only ever happens through the
+        // authenticated FontController::showHistoryImage route.
+        'history-images' => [
+            'driver' => env('FILESYSTEM_HISTORY_IMAGES_DRIVER', 'local'),
             'root' => storage_path('app/public'),
-            'url' => env('APP_URL').'/storage',
+            'visibility' => 'private',
             'throw' => false,
             'report' => false,
             'key' => env('AWS_ACCESS_KEY_ID'),

--- a/serverless.yml
+++ b/serverless.yml
@@ -32,7 +32,7 @@ provider:
         DB_SSLMODE: require
         # File storage (S3) - no AWS_ACCESS_KEY_ID/SECRET on purpose:
         # the Lambda execution role's IAM permissions (below) are used instead
-        FILESYSTEM_PUBLIC_DRIVER: s3
+        FILESYSTEM_HISTORY_IMAGES_DRIVER: s3
         AWS_BUCKET: fontray-uploads-058264330199-eu-central-1-an
         WHATFONTIS_API_KEY: ${ssm:/fontray/prod/whatfontis-api-key}
     iam:

--- a/tests/Feature/SearchHistoryTest.php
+++ b/tests/Feature/SearchHistoryTest.php
@@ -20,7 +20,7 @@ class SearchHistoryTest extends TestCase
     public function test_authenticated_user_successful_identification_saves_search_history(): void
     {
         $user = User::factory()->create();
-        Storage::fake('public');
+        Storage::fake('history-images');
 
         $this->mock(FontIdentificationService::class, function (MockInterface $mock) {
             $mock->shouldReceive('identify')
@@ -49,7 +49,7 @@ class SearchHistoryTest extends TestCase
         $this->assertSame($user->id, $saved->user_id);
         $this->assertIsString($saved->image_reference);
         $this->assertStringStartsWith('images/history/', $saved->image_reference);
-        $this->assertTrue(Storage::disk('public')->exists($saved->image_reference));
+        $this->assertTrue(Storage::disk('history-images')->exists($saved->image_reference));
         $this->assertSame(1, json_decode($saved->font_results, true)['total_found']);
     }
 
@@ -182,13 +182,13 @@ class SearchHistoryTest extends TestCase
 
     public function test_history_image_route_denies_access_to_other_user_history_image(): void
     {
-        Storage::fake('public');
+        Storage::fake('history-images');
 
         $owner = User::factory()->create();
         $otherUser = User::factory()->create();
 
         $path = UploadedFile::fake()->create('private-history.png', 100, 'image/png')
-            ->store('images/history', 'public');
+            ->store('images/history', 'history-images');
 
         $historyId = DB::table('search_histories')->insertGetId([
             'user_id' => $owner->id,
@@ -205,12 +205,12 @@ class SearchHistoryTest extends TestCase
 
     public function test_history_image_route_serves_owned_history_image(): void
     {
-        Storage::fake('public');
+        Storage::fake('history-images');
 
         $user = User::factory()->create();
 
         $path = UploadedFile::fake()->create('owned-history.png', 100, 'image/png')
-            ->store('images/history', 'public');
+            ->store('images/history', 'history-images');
 
         $historyId = DB::table('search_histories')->insertGetId([
             'user_id' => $user->id,


### PR DESCRIPTION
## Summary
Renames the "public" disk used for history images to "history-images" and sets its visibility to "private" explicitly. Access already goes exclusively through the authenticated `FontController::showHistoryImage` route, but the disk's name and missing visibility setting invited a future regression: if the S3 bucket ever allowed ACLs again, files could become reachable at a guessable direct URL, bypassing auth entirely.

## Changes
- `config/filesystems.php`: rename the disk to `history-images`, add `'visibility' => 'private'`, drop the now-unused `url` key
- `app/Http/Controllers/FontController.php`: update the 3 references from the `public` disk to `history-images`
- `serverless.yml`: rename `FILESYSTEM_PUBLIC_DRIVER` to `FILESYSTEM_HISTORY_IMAGES_DRIVER`
- `tests/Feature/SearchHistoryTest.php`: update fakes/disk references to match

## Test plan
- [x] All 64 tests pass
- [x] Verified no remaining references to the old `public` disk name or env var anywhere in the codebase