### PR TITLE
Clean up FontController nits from code review

### DIFF
--- a/app/Http/Controllers/FontController.php
+++ b/app/Http/Controllers/FontController.php
@@ -30,7 +30,7 @@ class FontController extends Controller
         $uploadedFile = $request->file('image');
         $file = $uploadedFile;
 
-        if ($file->getClientOriginalExtension() === 'pdf') {
+        if ($file->getMimeType() === 'application/pdf') {
             try {
                 $file = $this->pdfFirstPageImageExtractor->extract($file);
             } catch (\Throwable) {
@@ -64,7 +64,7 @@ class FontController extends Controller
             ]);
         }
 
-        $status = $result['status'] ?? ($result['success'] ? 200 : 200);
+        $status = $result['status'] ?? 200;
         unset($result['status']);
 
         return response()->json($result, $status);
@@ -101,7 +101,7 @@ class FontController extends Controller
             abort(404);
         }
 
-        if (! Str::startsWith($imageReference, ['images/', 'uploads/'])) {
+        if (! $this->isServableReference($imageReference)) {
             abort(404);
         }
 
@@ -124,10 +124,15 @@ class FontController extends Controller
             return $imageReference;
         }
 
-        if (Str::startsWith($imageReference, ['images/', 'uploads/'])) {
+        if ($this->isServableReference($imageReference)) {
             return route('history.image', ['history' => $history->id]);
         }
 
         return null;
+    }
+
+    private function isServableReference(string $imageReference): bool
+    {
+        return Str::startsWith($imageReference, ['images/', 'uploads/']);
     }
 }

--- a/tests/Feature/FontControllerTest.php
+++ b/tests/Feature/FontControllerTest.php
@@ -198,6 +198,52 @@ class FontControllerTest extends TestCase
         $response->assertJsonPath('message', 'No se pudo procesar el PDF. Verifica que el archivo sea válido e inténtalo nuevamente.');
     }
 
+    public function test_identify_ignores_pdf_extension_when_the_real_mime_type_is_not_pdf(): void
+    {
+        $file = UploadedFile::fake()->create('renamed.pdf', 100, 'image/png');
+
+        $this->mock(PdfFirstPageImageExtractor::class, function (MockInterface $mock) {
+            $mock->shouldNotReceive('extract');
+        });
+
+        $this->mock(FontIdentificationService::class, function (MockInterface $mock) use ($file) {
+            $mock->shouldReceive('identify')
+                ->once()
+                ->withArgs(fn (UploadedFile $passed) => $passed->getClientOriginalName() === $file->getClientOriginalName())
+                ->andReturn(['success' => true, 'fonts' => [], 'total_found' => 0]);
+        });
+
+        $response = $this->postJson('/identify', [
+            'image' => $file,
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_identify_extracts_pdf_first_page_even_with_a_non_pdf_file_extension(): void
+    {
+        $file = UploadedFile::fake()->create('misnamed.png', 100, 'application/pdf');
+        $firstPageImage = UploadedFile::fake()->create('misnamed-page-1.png', 50, 'image/png');
+
+        $this->mock(PdfFirstPageImageExtractor::class, function (MockInterface $mock) use ($firstPageImage) {
+            $mock->shouldReceive('extract')
+                ->once()
+                ->andReturn($firstPageImage);
+        });
+
+        $this->mock(FontIdentificationService::class, function (MockInterface $mock) {
+            $mock->shouldReceive('identify')
+                ->once()
+                ->andReturn(['success' => true, 'fonts' => [], 'total_found' => 0]);
+        });
+
+        $response = $this->postJson('/identify', [
+            'image' => $file,
+        ]);
+
+        $response->assertStatus(200);
+    }
+
     public function test_identify_endpoint_is_rate_limited_per_ip(): void
     {
         Http::fake([


### PR DESCRIPTION
## Summary
Bundles three small readability/correctness fixes to FontController flagged by the code review, all on the same file.

## Changes
- Detect PDF uploads by the real MIME type (`getMimeType()`) instead of the client-supplied file extension, which could be spoofed by simply renaming a file
- Remove a dead ternary (`$result['status'] ?? ($result['success'] ? 200 : 200)`) that always evaluated to 200 regardless of branch
- Extract `isServableReference()` to stop duplicating the images/uploads prefix check between `showHistoryImage` and `resolveHistoryImageUrl`

## Test plan
- [x] All 66 tests pass
- [x] New tests cover PDFs identified purely by MIME type in either direction (real PDF with a misleading `.png` name, and a non-PDF file with a misleading `.pdf` name)