### PR TITLE
Guard against a missing csrf meta tag in useFontIdentification

### DIFF
--- a/resources/js/composables/__tests__/useFontIdentification.test.js
+++ b/resources/js/composables/__tests__/useFontIdentification.test.js
@@ -98,6 +98,23 @@ describe('useFontIdentification', () => {
     expect(result.message).toContain('Error de conexión')
   })
 
+  it('identifyFont returns a friendly error when the csrf meta tag is missing', async () => {
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+    vi.spyOn(document, 'querySelector').mockReturnValue(null)
+
+    const { identifyFont } = useFontIdentification()
+    const image = new File(['img'], 'test.jpg', { type: 'image/jpeg' })
+    const resizeStub = vi.fn().mockResolvedValue(image)
+    const emitStub = vi.fn()
+
+    const result = await identifyFont(image, resizeStub, emitStub)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('sesión')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
   it('identifyFont does nothing if no image', async () => {
     const { identifyFont, isProcessing } = useFontIdentification()
     const resizeStub = vi.fn()

--- a/resources/js/composables/useFontIdentification.js
+++ b/resources/js/composables/useFontIdentification.js
@@ -9,6 +9,15 @@ export function useFontIdentification() {
     isProcessing.value = true
 
     try {
+      const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content')
+
+      if (!csrfToken) {
+        return {
+          success: false,
+          message: 'No se pudo verificar la sesión. Por favor, recarga la página e inténtalo de nuevo.',
+        }
+      }
+
       const processedImage = await resizeImageIfNeeded(image)
 
       const formData = new FormData()
@@ -18,9 +27,7 @@ export function useFontIdentification() {
         method: 'POST',
         body: formData,
         headers: {
-          'X-CSRF-TOKEN': document
-            .querySelector('meta[name="csrf-token"]')
-            .getAttribute('content'),
+          'X-CSRF-TOKEN': csrfToken,
         },
       })
 


### PR DESCRIPTION
## Summary
Reading the csrf-token meta tag's content unconditionally threw a TypeError if the tag was ever missing, which was silently caught by the outer try/catch and surfaced as a misleading "connection error" message. Now it's read with optional chaining and returns a specific, actionable message instead.

## Changes
- `resources/js/composables/useFontIdentification.js`: read the csrf token defensively and short-circuit with a clear error if it's missing
- `resources/js/composables/__tests__/useFontIdentification.test.js`: new test that removes the meta tag and asserts the friendly message, and that fetch is never called in that case

## Test plan
- [x] All 35 Vitest tests pass
- [x] Confirmed the pre-existing lint/format warnings on unrelated files are present on main as well, unaffected by this change