### PR TITLE
Attach Imagick/Ghostscript layer and harden its PDF policy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": "^8.2",
         "bref/bref": "*",
+        "bref/extra-php-extensions": "^3.0",
         "bref/laravel-bridge": "3.0.7",
         "inertiajs/inertia-laravel": "^2.0",
         "intervention/image": "^3.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cee47a52714874f4a87adf310d255211",
+    "content-hash": "dae43fc2b9959f0080f4f23f490004a4",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -234,6 +234,66 @@
                 }
             ],
             "time": "2026-07-09T09:30:10+00:00"
+        },
+        {
+            "name": "bref/extra-php-extensions",
+            "version": "3.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brefphp/extra-php-extensions.git",
+                "reference": "e2ef5a7ddc0ddd2e0f8455d46e857e8f993ce8cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brefphp/extra-php-extensions/zipball/e2ef5a7ddc0ddd2e0f8455d46e857e8f993ce8cb",
+                "reference": "e2ef5a7ddc0ddd2e0f8455d46e857e8f993ce8cb",
+                "shasum": ""
+            },
+            "conflict": {
+                "bref/bref": "<3.0.0"
+            },
+            "require-dev": {
+                "async-aws/core": "^1.7",
+                "async-aws/lambda": "^1.1",
+                "bref/logger": "^2.0",
+                "mnapoli/silly": "^1.7",
+                "mnapoli/silly-php-di": "^1.2",
+                "php-di/php-di": "^6.3",
+                "symfony/finder": "^5.4",
+                "symfony/http-client": "^5.4",
+                "symfony/process": "^5.4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                }
+            ],
+            "description": "Extra PHP extensions for your lambda application.",
+            "support": {
+                "issues": "https://github.com/brefphp/extra-php-extensions/issues",
+                "source": "https://github.com/brefphp/extra-php-extensions/tree/3.0.9"
+            },
+            "funding": [
+                {
+                    "url": "https://bref.sh/#enterprise",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-25T17:27:15+00:00"
         },
         {
             "name": "bref/laravel-bridge",

--- a/docker/imagick/policy.xml
+++ b/docker/imagick/policy.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+  <!ELEMENT policymap (policy)*>
+  <!ATTLIST policymap xmlns CDATA #FIXED ''>
+  <!ELEMENT policy EMPTY>
+  <!ATTLIST policy xmlns CDATA #FIXED '' domain NMTOKEN #REQUIRED name NMTOKEN #IMPLIED pattern CDATA #IMPLIED rights NMTOKEN #IMPLIED value CDATA #IMPLIED>
+]>
+<!--
+  Hardened policy for the Lambda "web" function, which only ever needs to
+  *read* an untrusted, user-uploaded PDF and rasterize its first page
+  (PdfFirstPageImageExtractor). Loaded via MAGICK_CONFIGURE_PATH; any config
+  file not present here (delegates.xml, type.xml, ...) still falls back to
+  ImageMagick's normal search path and compiled-in defaults.
+-->
+<policymap>
+  <!-- PDF: read-only. We never write PDFs, so no delegate should be able to
+       trick ImageMagick into producing one. -->
+  <policy domain="coder" rights="read" pattern="PDF" />
+
+  <!-- The ImageTragick (CVE-2016-3714) family of delegate coders. None of
+       these are needed for image identification; disable them outright. -->
+  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+  <policy domain="coder" rights="none" pattern="URL" />
+  <policy domain="coder" rights="none" pattern="HTTPS" />
+  <policy domain="coder" rights="none" pattern="MVG" />
+  <policy domain="coder" rights="none" pattern="MSL" />
+  <policy domain="coder" rights="none" pattern="TEXT" />
+  <policy domain="coder" rights="none" pattern="SHOW" />
+  <policy domain="coder" rights="none" pattern="WIN" />
+  <policy domain="coder" rights="none" pattern="PLT" />
+  <policy domain="coder" rights="none" pattern="LABEL" />
+
+  <!-- Block "@filename" indirect reads (e.g. "@/etc/passwd"). -->
+  <policy domain="path" rights="none" pattern="@*" />
+
+  <!-- Cap the resources a single hostile PDF can make Ghostscript consume. -->
+  <policy domain="resource" name="memory" value="256MiB" />
+  <policy domain="resource" name="map" value="512MiB" />
+  <policy domain="resource" name="width" value="8000" />
+  <policy domain="resource" name="height" value="8000" />
+  <policy domain="resource" name="area" value="64MP" />
+  <policy domain="resource" name="disk" value="512MiB" />
+  <policy domain="resource" name="time" value="20" />
+</policymap>

--- a/serverless.yml
+++ b/serverless.yml
@@ -56,6 +56,14 @@ functions:
         handler: public/index.php
         runtime: php-84-fpm
         timeout: 28 # in seconds (API Gateway has a timeout of 29 seconds)
+        layers:
+            # Imagick + Ghostscript, needed to rasterize the first page of
+            # user-uploaded PDFs (see PdfFirstPageImageExtractor)
+            - ${bref-extra:imagick-php-84}
+        environment:
+            # Hardened policy.xml for ImageMagick/Ghostscript against untrusted
+            # PDFs; other config files still fall back to IM's defaults
+            MAGICK_CONFIGURE_PATH: /var/task/docker/imagick
         events:
             - httpApi: '*'
 
@@ -148,6 +156,8 @@ package:
 plugins:
     # We need to include the Bref plugin
     - ./vendor/bref/bref
+    # Resolves ${bref-extra:...} layer references (e.g. imagick-php-84)
+    - ./vendor/bref/extra-php-extensions
     # Uncomment the Serverless Lift plugin if you use constructs
     # See https://github.com/getlift/lift
     - serverless-lift


### PR DESCRIPTION
## Summary
The "web" Lambda function only has Bref's base php-84 layer, which does not include ext-imagick — confirmed live via tinker that class_exists('Imagick') is false in production. Every real PDF upload has therefore always fatal-errored in PdfFirstPageImageExtractor, masked by FontController's generic catch handler.

Since this makes PDF processing work against untrusted input for the first time, this PR also ships a hardened policy.xml alongside it rather than deploying an unrestricted Imagick.

## Changes
- `composer.json`/`composer.lock`: add `bref/extra-php-extensions` (^3.0)
- `serverless.yml`: attach `${bref-extra:imagick-php-84}` to the `web` function (resolves to `arn:aws:lambda:eu-central-1:403367587399:layer:imagick-php-84:8`), set `MAGICK_CONFIGURE_PATH`, register the new plugin
- `docker/imagick/policy.xml` (new): PDF stays read-only; the ImageTragick family of delegate coders (MVG, MSL, URL, HTTPS, EPHEMERAL, TEXT, SHOW, WIN, PLT, LABEL) is disabled; indirect `@file` reads are blocked; per-request resource limits are capped (256MiB memory, 8000px, 20s)

## Test plan
- [x] All 66 PHP tests pass
- [x] `npx serverless package` resolves the layer ARN correctly and bundles `docker/imagick/policy.xml` into the deployment zip
- [x] With `MAGICK_CONFIGURE_PATH` set locally in Sail, PDF reading still succeeds and resource limits measurably drop from Debian's defaults (1GB/32000px) to ours (256MiB/8000px), proving the custom policy loads and applies
- [ ] Manual verification with a real PDF upload against production, after this merges and auto-deploys via `.github/workflows/deploy.yml`