### PR TITLE
Allow uploading PDFs from the upload UI

### DIFF
--- a/e2e/font-identification.spec.js
+++ b/e2e/font-identification.spec.js
@@ -5,7 +5,7 @@ test('full flow: upload image -> identify -> see results', async ({ page }) => {
 
   await expect(page.locator('h1')).toContainText('Identifica cualquier')
 
-  const fileInput = page.locator('input[type="file"][accept="image/*"]')
+  const fileInput = page.locator('input[type="file"]')
   await fileInput.setInputFiles('tests/Fixtures/test_image.jpg')
 
   await expect(page.locator('img[alt="Imagen seleccionada"]')).toBeVisible()
@@ -27,7 +27,7 @@ test('upload flow: upload image -> crop/rotate/contrast -> identify', async ({
 }) => {
   await page.goto('/')
 
-  const fileInput = page.locator('input[type="file"][accept="image/*"]')
+  const fileInput = page.locator('input[type="file"]')
   await fileInput.setInputFiles('tests/Fixtures/test_image.jpg')
 
   await expect(page.locator('img[alt="Imagen seleccionada"]')).toBeVisible()
@@ -82,7 +82,7 @@ test('upload flow: upload image -> crop/rotate/contrast -> identify', async ({
 test('upload validation: rejects non-image file', async ({ page }) => {
   await page.goto('/')
 
-  const fileInput = page.locator('input[type="file"][accept="image/*"]')
+  const fileInput = page.locator('input[type="file"]')
   await fileInput.setInputFiles({
     name: 'not-image.txt',
     mimeType: 'text/plain',
@@ -90,8 +90,30 @@ test('upload validation: rejects non-image file', async ({ page }) => {
   })
 
   await expect(
-    page.getByText('Por favor selecciona un archivo de imagen válido.')
+    page.getByText('Por favor selecciona una imagen o un PDF válido.')
   ).toBeVisible()
+})
+
+test('upload flow: upload PDF -> identify', async ({ page }) => {
+  await page.goto('/')
+
+  const fileInput = page.locator('input[type="file"]')
+  await fileInput.setInputFiles('tests/Fixtures/blank_page.pdf')
+
+  await expect(page.getByText('PDF seleccionado')).toBeVisible()
+  await expect(page.getByText('blank_page.pdf')).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: /Recortar imagen/i })
+  ).toHaveCount(0)
+
+  const identifyButton = page.getByRole('button', {
+    name: /Identificar fuente/i,
+  })
+  await identifyButton.click()
+
+  await expect(
+    page.getByRole('heading', { name: /Resultados de Identificación/i })
+  ).toBeVisible({ timeout: 15000 })
 })
 
 test('navigation: examples/privacy/terms/home all load correctly', async ({

--- a/e2e/history.spec.js
+++ b/e2e/history.spec.js
@@ -62,7 +62,7 @@ test('authenticated user sees search history after identification', async ({
 
   // Navigate to home and upload an image
   await page.goto('/')
-  const fileInput = page.locator('input[type="file"][accept="image/*"]')
+  const fileInput = page.locator('input[type="file"]')
   await fileInput.setInputFiles('tests/Fixtures/test_image.jpg')
   await expect(page.locator('img[alt="Imagen seleccionada"]')).toBeVisible()
 

--- a/resources/js/Components/ImageUploader.vue
+++ b/resources/js/Components/ImageUploader.vue
@@ -85,7 +85,7 @@
           </div>
 
           <p class="text-sm text-gray-500 mt-3">
-            Soporta JPG, PNG, WebP hasta 10MB
+            Soporta JPG, PNG, WebP o PDF hasta 10MB
           </p>
         </div>
       </div>
@@ -94,10 +94,30 @@
       <div v-else class="space-y-4">
         <div class="relative">
           <img
+            v-if="!isPdfSelected"
             :src="previewUrl"
             alt="Imagen seleccionada"
             class="max-w-full max-h-64 mx-auto rounded-lg shadow-lg"
           />
+          <div
+            v-else
+            class="flex items-center justify-center gap-3 max-w-xs mx-auto rounded-lg border border-gray-200 bg-gray-50 p-6"
+          >
+            <svg
+              class="w-10 h-10 text-gray-400 flex-shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+              />
+            </svg>
+            <span class="text-gray-700 font-medium break-all">PDF seleccionado</span>
+          </div>
 
           <!-- Remove button -->
           <button
@@ -127,8 +147,9 @@
 
           <!-- Action Buttons -->
           <div class="flex flex-col sm:flex-row gap-3">
-            <!-- Crop Button -->
+            <!-- Crop Button: cropping only applies to raster images, not PDFs -->
             <button
+              v-if="!isPdfSelected"
               class="bg-primary hover:bg-primary-dark hover:shadow-lg text-white font-medium py-3 px-8 rounded-lg transition-all cursor-pointer"
               @click="openCropper"
             >
@@ -178,7 +199,7 @@
     <input
       ref="fileInput"
       type="file"
-      accept="image/*"
+      accept="image/*,application/pdf"
       class="hidden"
       @change="handleFileSelect"
     />
@@ -586,7 +607,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { router } from '@inertiajs/vue3'
 import ImageCropper from './ImageCropper.vue'
 import { useImageUpload } from '@/composables/useImageUpload'
@@ -615,6 +636,8 @@ const { isProcessing, identifyFont: identifyFontCore } = useFontIdentification()
 // Refs
 const fileInput = ref(null)
 const showCropper = ref(false)
+
+const isPdfSelected = computed(() => selectedImage.value?.type === 'application/pdf')
 
 // Camera related
 const showCamera = ref(false)

--- a/resources/js/Components/__tests__/ImageUploader.test.js
+++ b/resources/js/Components/__tests__/ImageUploader.test.js
@@ -96,6 +96,26 @@ describe('ImageUploader', () => {
     expect(wrapper.text()).toContain('Por favor selecciona un archivo de imagen válido.')
   })
 
+  it('shows a PDF placeholder instead of an image preview and hides the crop button', async () => {
+    state.selectedImage.value = { name: 'document.pdf', size: 10000, type: 'application/pdf' }
+    state.previewUrl.value = 'data:application/pdf;base64,mock'
+
+    const wrapper = mount(ImageUploader, {
+      global: {
+        stubs: {
+          ImageCropper: true,
+        },
+      },
+    })
+
+    await nextTick()
+
+    expect(wrapper.find('img[alt="Imagen seleccionada"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('PDF seleccionado')
+    expect(wrapper.text()).toContain('document.pdf')
+    expect(wrapper.findAll('button').find((btn) => btn.text().includes('Recortar imagen'))).toBeFalsy()
+  })
+
   it('calls identifyFont when button clicked', async () => {
     state.selectedImage.value = { name: 'test.jpg', size: 10000 }
     state.previewUrl.value = 'blob:mock-url'

--- a/resources/js/composables/__tests__/useImageUpload.test.js
+++ b/resources/js/composables/__tests__/useImageUpload.test.js
@@ -8,8 +8,18 @@ describe('useImageUpload', () => {
     const textFile = new File(['hello'], 'doc.txt', { type: 'text/plain' })
     processFile(textFile)
 
-    expect(error.value).toContain('imagen válido')
+    expect(error.value).toContain('imagen o un PDF')
     expect(selectedImage.value).toBeNull()
+  })
+
+  it('processFile accepts a PDF file', () => {
+    const { processFile, selectedImage, error } = useImageUpload()
+
+    const pdfFile = new File(['fake-pdf'], 'document.pdf', { type: 'application/pdf' })
+    processFile(pdfFile)
+
+    expect(error.value).toBe('')
+    expect(selectedImage.value.name).toBe(pdfFile.name)
   })
 
   it('processFile validates file size (max 10MB)', () => {

--- a/resources/js/composables/useImageUpload.js
+++ b/resources/js/composables/useImageUpload.js
@@ -11,8 +11,8 @@ export function useImageUpload() {
     error.value = ''
     success.value = ''
 
-    if (!file.type.startsWith('image/')) {
-      error.value = 'Por favor selecciona un archivo de imagen válido.'
+    if (!file.type.startsWith('image/') && file.type !== 'application/pdf') {
+      error.value = 'Por favor selecciona una imagen o un PDF válido.'
       return
     }
 


### PR DESCRIPTION
## Summary
The file picker and useImageUpload.js only accepted image/* MIME types, so a PDF was rejected before ever reaching the backend (which has always supported PDF via IdentifyFontRequest).

## Changes
- Accept application/pdf in both the file input's accept attribute and useImageUpload.js's validation
- Show a simple placeholder instead of a broken <img> preview for PDFs (they can't be rendered as an image)
- Hide the crop button for PDFs since cropping doesn't apply
- Update the two E2E specs whose selector depended on the old accept="image/*" attribute
- Add a new E2E case that uploads a real PDF end to end

## Test plan
- [x] All 37 Vitest tests pass
- [x] Manually verified against the real backend (via Sail) that a PDF now reaches FontController and the WhatFontIs API instead of being rejected client-side
- [x] Could not run the Playwright suite in this environment — playwright.config.js hardcodes a machine-specific sqlite path that only exists on the author's own machine, unrelated to this change