### PR TITLE
Make the rate limiter's cache store reliable on Neon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,12 @@ DB_CONNECTION=sqlite
 # DB_DATABASE=laravel
 # DB_USERNAME=sail
 # DB_PASSWORD=
+# When DB_HOST is a pooled connection (e.g. Neon's "-pooler" endpoint), set
+# DB_HOST_DIRECT to the non-pooled endpoint and DB_CACHE_CONNECTION=pgsql_direct
+# so the rate limiter's Cache::increment() gets a connection that reliably
+# supports multi-statement transactions.
+# DB_HOST_DIRECT=
+# DB_CACHE_CONNECTION=
 
 SESSION_DRIVER=database
 SESSION_LIFETIME=120

--- a/config/database.php
+++ b/config/database.php
@@ -97,6 +97,25 @@ return [
             'sslmode' => env('DB_SSLMODE', 'prefer'),
         ],
 
+        // Same database as "pgsql", but via Neon's direct (non-pooled) endpoint.
+        // The database cache store's increment()/RateLimiter needs a real
+        // multi-statement transaction (SELECT ... FOR UPDATE + UPDATE), which
+        // Neon's pooler does not reliably support. Used only for DB_CACHE_CONNECTION.
+        'pgsql_direct' => [
+            'driver' => 'pgsql',
+            'url' => env('DB_URL'),
+            'host' => env('DB_HOST_DIRECT', env('DB_HOST', '127.0.0.1')),
+            'port' => env('DB_PORT', '5432'),
+            'database' => env('DB_DATABASE', 'laravel'),
+            'username' => env('DB_USERNAME', 'root'),
+            'password' => env('DB_PASSWORD', ''),
+            'charset' => env('DB_CHARSET', 'utf8'),
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'search_path' => 'public',
+            'sslmode' => env('DB_SSLMODE', 'prefer'),
+        ],
+
         'sqlsrv' => [
             'driver' => 'sqlsrv',
             'url' => env('DB_URL'),

--- a/database/migrations/2026_07_21_140000_add_unique_index_to_cache_key.php
+++ b/database/migrations/2026_07_21_140000_add_unique_index_to_cache_key.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The Neon pooler connection this app uses does not reliably persist
+     * DDL run inside Laravel's automatic per-migration transaction wrapper
+     * (observed: migrate reported success, but the constraint never
+     * actually existed afterwards). Running outside a transaction avoids it.
+     */
+    public $withinTransaction = false;
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('cache', function (Blueprint $table) {
+            $table->unique('key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('cache', function (Blueprint $table) {
+            $table->dropUnique(['key']);
+        });
+    }
+};

--- a/serverless.yml
+++ b/serverless.yml
@@ -30,6 +30,12 @@ provider:
         DB_USERNAME: neondb_owner
         DB_PASSWORD: ${ssm:/fontray/prod/db-password}
         DB_SSLMODE: require
+        # Direct (non-pooled) endpoint, used only by the "pgsql_direct"
+        # connection: the rate limiter's Cache::increment() needs a real
+        # multi-statement transaction, which Neon's pooler does not
+        # reliably support.
+        DB_HOST_DIRECT: ep-fancy-meadow-asys5td7.c-4.eu-central-1.aws.neon.tech
+        DB_CACHE_CONNECTION: pgsql_direct
         # File storage (S3) - no AWS_ACCESS_KEY_ID/SECRET on purpose:
         # the Lambda execution role's IAM permissions (below) are used instead
         FILESYSTEM_HISTORY_IMAGES_DRIVER: s3


### PR DESCRIPTION
## Summary
Two compounding bugs broke Cache::increment()/put(), used by the identify rate limiter added in a previous fix, causing intermittent 500 errors on every /identify request.

## Changes
- New migration: adds the unique constraint missing from the "cache" table's key column (a pre-existing gap in the stock migration), required by Postgres for the ON CONFLICT upserts the database cache driver issues. Runs outside a transaction — Laravel's default per-migration transaction wrapper reported success without the DDL actually persisting against this connection.
- `config/database.php`: new "pgsql_direct" connection pointing at Neon's direct (non-pooled) endpoint.
- `serverless.yml`: `DB_HOST_DIRECT` + `DB_CACHE_CONNECTION=pgsql_direct`, so the cache store uses the direct connection while the app's primary queries stay on the pooler.
- `.env.example`: documents the pattern.

Root cause for the direct-connection change: verified in isolation that Neon's pooled endpoint does not reliably support the multi-statement transaction (SELECT ... FOR UPDATE + UPDATE) that Cache::increment() relies on, while the identical operation against Neon's direct endpoint succeeds every time.

## Test plan
- [x] All 66 PHP tests pass
- [x] Verified locally end to end: a real /identify request now passes the throttle middleware cleanly and reaches the WhatFontIs API instead of 500ing
- [x] The missing unique index has already been applied directly against the production database and confirmed to persist