### PR TITLE
Enable binary responses so history images don't 500

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -70,6 +70,11 @@ functions:
             # Hardened policy.xml for ImageMagick/Ghostscript against untrusted
             # PDFs; other config files still fall back to IM's defaults
             MAGICK_CONFIGURE_PATH: /var/task/docker/imagick
+            # Without this, Bref sends binary bodies (e.g. history images
+            # served via Storage::response()) as raw UTF-8 in the Lambda
+            # JSON payload, which fails with "Malformed UTF-8 characters".
+            # See https://bref.sh/docs/use-cases/http/binary-requests-responses
+            BREF_BINARY_RESPONSES: '1'
         events:
             - httpApi: '*'
 


### PR DESCRIPTION
## Summary
GET /history/{id}/image (FontController::showHistoryImage) streams a binary image via Storage::response(). Without BREF_BINARY_RESPONSES, Bref sends the response body as raw UTF-8 inside the Lambda JSON payload, which fails once the bytes aren't valid UTF-8: "The Lambda response cannot be encoded to JSON... Malformed UTF-8 characters", surfacing to the browser as a 500.

Confirmed via CloudWatch logs on the deployed "web" function that this was the exact error on every request to that route.

## Changes
- `serverless.yml`: add `BREF_BINARY_RESPONSES: '1'` to the `web` function's environment, so Bref base64-encodes the body and sets isBase64Encoded, per https://bref.sh/docs/use-cases/http/binary-requests-responses

## Test plan
- [x] All 66 PHP tests pass (this config change isn't exercised by them)
- [x] Confirmed the exact failure mode via CloudWatch logs on the live "web" function
- [ ] Cannot be verified locally — Sail doesn't go through Bref's Lambda HTTP bridge. Needs a real deploy + a manual check of /history on production