### PR TITLE
Address nits from the post-fix code review

### DIFF
--- a/app/Http/Controllers/FontController.php
+++ b/app/Http/Controllers/FontController.php
@@ -9,6 +9,7 @@ use App\Services\PdfFirstPageImageExtractor;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
@@ -49,8 +50,13 @@ class FontController extends Controller
             try {
                 $fileToPersist = $file;
                 $imageReference = $fileToPersist->store('images/history', 'history-images');
-            } catch (\Throwable) {
-                // Mantener compatibilidad en caso de fallo al persistir imagen.
+            } catch (\Throwable $e) {
+                // Mantener compatibilidad en caso de fallo al persistir imagen:
+                // el historial se guarda igualmente, mostrando el nombre original.
+                Log::warning('Failed to persist history image', [
+                    'user_id' => Auth::id(),
+                    'message' => $e->getMessage(),
+                ]);
             }
 
             SearchHistory::create([

--- a/config/database.php
+++ b/config/database.php
@@ -82,6 +82,8 @@ return [
             ]) : [],
         ],
 
+        // Kept in sync with "pgsql_direct" below (same options, different
+        // host) — if you add an option to one, add it to the other too.
         'pgsql' => [
             'driver' => 'pgsql',
             'url' => env('DB_URL'),

--- a/database/migrations/2026_07_21_140000_add_unique_index_to_cache_key.php
+++ b/database/migrations/2026_07_21_140000_add_unique_index_to_cache_key.php
@@ -11,6 +11,10 @@ return new class extends Migration
      * DDL run inside Laravel's automatic per-migration transaction wrapper
      * (observed: migrate reported success, but the constraint never
      * actually existed afterwards). Running outside a transaction avoids it.
+     *
+     * This is also why serverless.yml overrides DB_HOST to Neon's direct
+     * (non-pooled) endpoint specifically for the "artisan" function, which is
+     * the one that runs migrations in production.
      */
     public $withinTransaction = false;
 

--- a/docker/imagick/policy.xml
+++ b/docker/imagick/policy.xml
@@ -21,7 +21,9 @@
        these are needed for image identification; disable them outright. -->
   <policy domain="coder" rights="none" pattern="EPHEMERAL" />
   <policy domain="coder" rights="none" pattern="URL" />
+  <policy domain="coder" rights="none" pattern="HTTP" />
   <policy domain="coder" rights="none" pattern="HTTPS" />
+  <policy domain="coder" rights="none" pattern="FTP" />
   <policy domain="coder" rights="none" pattern="MVG" />
   <policy domain="coder" rights="none" pattern="MSL" />
   <policy domain="coder" rights="none" pattern="TEXT" />
@@ -29,6 +31,10 @@
   <policy domain="coder" rights="none" pattern="WIN" />
   <policy domain="coder" rights="none" pattern="PLT" />
   <policy domain="coder" rights="none" pattern="LABEL" />
+  <policy domain="coder" rights="none" pattern="PS" />
+  <policy domain="coder" rights="none" pattern="EPS" />
+  <policy domain="coder" rights="none" pattern="XPS" />
+  <policy domain="coder" rights="none" pattern="MAGICK" />
 
   <!-- Block "@filename" indirect reads (e.g. "@/etc/passwd"). -->
   <policy domain="path" rights="none" pattern="@*" />

--- a/resources/js/Components/ImageUploader.vue
+++ b/resources/js/Components/ImageUploader.vue
@@ -29,10 +29,10 @@
 
         <div>
           <h3 class="text-lg font-semibold text-gray-900 mb-2">
-            Sube tu imagen
+            Sube tu imagen o PDF
           </h3>
           <p class="text-gray-600 mb-4">
-            Arrastra y suelta una imagen aquí, o haz clic para seleccionar
+            Arrastra y suelta una imagen o PDF aquí, o haz clic para seleccionar
           </p>
 
           <!-- Upload Buttons -->
@@ -54,7 +54,7 @@
                   d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 12l2 2 4-4"
                 />
               </svg>
-              Seleccionar imagen
+              Seleccionar archivo
             </button>
 
             <button
@@ -105,6 +105,7 @@
           >
             <svg
               class="w-10 h-10 text-gray-400 flex-shrink-0"
+              aria-hidden="true"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -116,7 +117,9 @@
                 d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
               />
             </svg>
-            <span class="text-gray-700 font-medium break-all">PDF seleccionado</span>
+            <span class="text-gray-700 font-medium break-all">
+              PDF seleccionado
+            </span>
           </div>
 
           <!-- Remove button -->
@@ -610,7 +613,7 @@
 import { ref, computed } from 'vue'
 import { router } from '@inertiajs/vue3'
 import ImageCropper from './ImageCropper.vue'
-import { useImageUpload } from '@/composables/useImageUpload'
+import { useImageUpload, PDF_MIME_TYPE } from '@/composables/useImageUpload'
 import { useFontIdentification } from '@/composables/useFontIdentification'
 
 // Emits
@@ -637,7 +640,9 @@ const { isProcessing, identifyFont: identifyFontCore } = useFontIdentification()
 const fileInput = ref(null)
 const showCropper = ref(false)
 
-const isPdfSelected = computed(() => selectedImage.value?.type === 'application/pdf')
+const isPdfSelected = computed(
+  () => selectedImage.value?.type === PDF_MIME_TYPE
+)
 
 // Camera related
 const showCamera = ref(false)

--- a/resources/js/Components/__tests__/ImageUploader.test.js
+++ b/resources/js/Components/__tests__/ImageUploader.test.js
@@ -21,6 +21,7 @@ const state = {
 
 vi.mock('../../composables/useImageUpload', () => ({
   useImageUpload: () => state,
+  PDF_MIME_TYPE: 'application/pdf',
 }))
 
 vi.mock('../../composables/useFontIdentification', () => ({
@@ -59,7 +60,7 @@ describe('ImageUploader', () => {
     })
 
     expect(wrapper.text()).toContain('Sube tu imagen')
-    expect(wrapper.text()).toContain('Seleccionar imagen')
+    expect(wrapper.text()).toContain('Seleccionar archivo')
   })
 
   it('shows preview when image is selected', async () => {

--- a/resources/js/composables/__tests__/useFontIdentification.test.js
+++ b/resources/js/composables/__tests__/useFontIdentification.test.js
@@ -103,7 +103,7 @@ describe('useFontIdentification', () => {
     vi.stubGlobal('fetch', mockFetch)
     vi.spyOn(document, 'querySelector').mockReturnValue(null)
 
-    const { identifyFont } = useFontIdentification()
+    const { identifyFont, isProcessing } = useFontIdentification()
     const image = new File(['img'], 'test.jpg', { type: 'image/jpeg' })
     const resizeStub = vi.fn().mockResolvedValue(image)
     const emitStub = vi.fn()
@@ -112,6 +112,7 @@ describe('useFontIdentification', () => {
 
     expect(result.success).toBe(false)
     expect(result.message).toContain('sesión')
+    expect(isProcessing.value).toBe(false)
     expect(mockFetch).not.toHaveBeenCalled()
   })
 

--- a/resources/js/composables/__tests__/useImageUpload.test.js
+++ b/resources/js/composables/__tests__/useImageUpload.test.js
@@ -12,14 +12,20 @@ describe('useImageUpload', () => {
     expect(selectedImage.value).toBeNull()
   })
 
-  it('processFile accepts a PDF file', () => {
-    const { processFile, selectedImage, error } = useImageUpload()
+  it('processFile accepts a PDF file without generating a data URL preview', () => {
+    const readAsDataURLSpy = vi.spyOn(FileReader.prototype, 'readAsDataURL')
+    const { processFile, selectedImage, previewUrl, error, success } = useImageUpload()
 
     const pdfFile = new File(['fake-pdf'], 'document.pdf', { type: 'application/pdf' })
     processFile(pdfFile)
 
     expect(error.value).toBe('')
     expect(selectedImage.value.name).toBe(pdfFile.name)
+    expect(previewUrl.value).toBe('')
+    expect(success.value).toContain('Archivo cargado')
+    expect(readAsDataURLSpy).not.toHaveBeenCalled()
+
+    readAsDataURLSpy.mockRestore()
   })
 
   it('processFile validates file size (max 10MB)', () => {

--- a/resources/js/composables/useImageUpload.js
+++ b/resources/js/composables/useImageUpload.js
@@ -1,5 +1,7 @@
 import { ref } from 'vue'
 
+export const PDF_MIME_TYPE = 'application/pdf'
+
 export function useImageUpload() {
   const isDragging = ref(false)
   const selectedImage = ref(null)
@@ -11,7 +13,9 @@ export function useImageUpload() {
     error.value = ''
     success.value = ''
 
-    if (!file.type.startsWith('image/') && file.type !== 'application/pdf') {
+    const isPdf = file.type === PDF_MIME_TYPE
+
+    if (!file.type.startsWith('image/') && !isPdf) {
       error.value = 'Por favor selecciona una imagen o un PDF válido.'
       return
     }
@@ -23,13 +27,20 @@ export function useImageUpload() {
 
     selectedImage.value = file
 
-    const reader = new FileReader()
-    reader.onload = (e) => {
-      previewUrl.value = e.target.result
+    // A PDF can't be rendered as an <img>, so there's no point reading it
+    // into a data URL just to display a placeholder (see ImageUploader.vue).
+    if (!isPdf) {
+      const reader = new FileReader()
+      reader.onload = (e) => {
+        previewUrl.value = e.target.result
+      }
+      reader.readAsDataURL(file)
     }
-    reader.readAsDataURL(file)
 
-    if (file.size > 2 * 1024 * 1024) {
+    if (isPdf) {
+      success.value =
+        'Archivo cargado correctamente. ¡Haz clic en "Identificar fuente" para continuar!'
+    } else if (file.size > 2 * 1024 * 1024) {
       success.value =
         'Imagen cargada correctamente. Nota: La imagen es grande y será redimensionada automáticamente para optimizar el proceso de identificación.'
     } else {


### PR DESCRIPTION
## Summary
Follow-up cleanup after a fresh code-review pass over the 10 PRs merged in the previous session (rate limiting, PDF extraction, error classifier, S3 disk visibility, controller cleanup, CSRF guard, Imagick hardening, PDF upload UI, rate limiter reliability, binary responses). One Required fix and several small nits/hardening items across backend and frontend.

## Changes
- `FontController.php`: log a warning when persisting a history image fails, instead of silently swallowing the exception — previously the request still reported success while the image vanished, with nothing in CloudWatch to explain a later 404
- `docker/imagick/policy.xml`: block HTTP, FTP, PS/EPS, XPS and MAGICK coders alongside the ones already denied. Verified PDF rasterization still works under MAGICK_CONFIGURE_PATH
- `config/database.php` / migration: cross-referencing comments between the "pgsql"/"pgsql_direct" connections and why DDL needs to run outside a transaction on this Neon connection
- Frontend: skip the base64 data-URL read entirely for PDFs (it was never used, since PDFs show a placeholder instead of an `<img>`), mention PDF in the upload copy, centralize the `'application/pdf'` literal into a `PDF_MIME_TYPE` constant, mark the placeholder icon `aria-hidden`
- Tests: assert `isProcessing` resets after the CSRF-missing early return, and that no data URL read is attempted for PDFs

## Test plan
- [x] All 66 PHP tests pass
- [x] All 37 Vitest tests pass
- [x] Pint clean
- [x] Manually verified the hardened ImageMagick policy still allows PDF rasterization locally